### PR TITLE
19/10/2018 added a new maven version for com.fasterxml.jackson.core:j…

### DIFF
--- a/fcs-existdb/pom.xml
+++ b/fcs-existdb/pom.xml
@@ -29,11 +29,13 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.7.3</version>
         </dependency>-->
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.2</version>
+            <version>2.9.7</version>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
…ackson-databind ~> 2.9.7 (security reason)